### PR TITLE
feat: repair create topic form

### DIFF
--- a/docs/server-api.http
+++ b/docs/server-api.http
@@ -61,7 +61,9 @@ Authorization: Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJqdGkiOiJmODM0NTI5M
   "topic_id": 16,
   "name": "topic16",
   "partitions_count": 10,
-  "message_expiry": 0
+  "message_expiry": 0,
+  "compression_algorithm": "none",
+  "max_topic_size": "1000000000"
 }
 
  

--- a/src/lib/api/ApiSchema.ts
+++ b/src/lib/api/ApiSchema.ts
@@ -98,10 +98,13 @@ type Topics =
       method: 'POST';
       path: `/streams/${number}/topics`;
       body: {
-        topic_id: number;
+        compression_algorithm: "none" | "gzip";
+        max_topic_size: number;
+        message_expiry: number;
         name: string;
         partitions_count: number;
-        message_expiry: number;
+        stream_id: number;
+        topic_id: number;
       };
     }
   | {
@@ -110,6 +113,7 @@ type Topics =
       body: {
         name: string;
         message_expiry: number;
+        compression_algorithm: number;
       };
     }
   | {

--- a/src/lib/components/Modals/AddTopicModal.svelte
+++ b/src/lib/components/Modals/AddTopicModal.svelte
@@ -2,6 +2,7 @@
   import { setError, superForm, superValidateSync } from 'sveltekit-superforms/client';
   import { z } from 'zod';
   import Input from '../Input.svelte';
+  import Select from '../Select.svelte';
   import Button from '../Button.svelte';
   import ModalBase from './ModalBase.svelte';
   import type { CloseModalFn } from '$lib/types/utilTypes';
@@ -26,7 +27,9 @@
       .min(1, 'Name must contain at least 1 character')
       .max(255, 'Name must not exceed 255 characters'),
     partitions_count: z.number().min(0).max(numberSizes.max.u32).default(1),
-    message_expiry: z.number().min(0).max(numberSizes.max.u32)
+    message_expiry: z.number().min(0).max(numberSizes.max.u32),
+    compression_algorithm: z.enum(["none", "gzip"]).default("none"),
+    max_topic_size: z.number().min(0).max(numberSizes.max.u32).default(1_000_000_000),
   });
 
   const { form, errors, enhance, constraints } = superForm(superValidateSync(schema), {
@@ -43,7 +46,9 @@
           topic_id: form.data.topic_id,
           name: form.data.name,
           partitions_count: form.data.partitions_count,
-          message_expiry: form.data.message_expiry
+          message_expiry: form.data.message_expiry,
+          compression_algorithm: form.data.compression_algorithm,
+          max_topic_size: form.data.max_topic_size,
         }
       });
 
@@ -66,7 +71,7 @@
 </script>
 
 <ModalBase {closeModal} title="Add topic">
-  <form method="POST" class="flex flex-col h-[450px] gap-4" use:enhance>
+  <form method="POST" class="flex flex-col h-[650px] gap-4" use:enhance>
     <Input
       label="Id"
       name="topic_id"
@@ -99,9 +104,29 @@
       {...$constraints.message_expiry}
       errorMessage={$errors.message_expiry?.join(',')}
     />
-    <span class="text-xs text-shadeD200 dark:text-shadeL700 -mt-1">
+    
+    <span class="-mt-1 text-xs text-shadeD200 dark:text-shadeL700">
       {durationFormatter(+$form.message_expiry || 0)}
     </span>
+    
+    <Select
+      label="Compression Algorithm"
+      type="text"
+      name="compressionAlgorithm"
+      options={["none", "gzip"]}
+      bind:value={$form.compression_algorithm}
+      {...$constraints.compression_algorithm}
+      errorMessage={$errors.compression_algorithm?.join(',')}
+    />
+
+    <Input
+      label="Max topic size"
+      type="number"
+      name="maxTopicSize"
+      bind:value={$form.max_topic_size}
+      {...$constraints.max_topic_size}
+      errorMessage={$errors.max_topic_size?.join(',')}
+    />
 
     <div class="flex justify-end gap-3 mt-auto">
       <Button variant="text" type="button" class="w-2/5" on:click={() => closeModal()}

--- a/src/lib/components/Select.svelte
+++ b/src/lib/components/Select.svelte
@@ -1,0 +1,72 @@
+<script lang="ts">
+  import type { HTMLInputAttributes, HTMLInputTypeAttribute } from 'svelte/elements';
+  import { twMerge } from 'tailwind-merge';
+
+  interface $$Props extends HTMLInputAttributes {
+    errorMessage?: string;
+    id?: string;
+    label?: string;
+    name: string;
+    options: Array<string>;
+    type?: HTMLInputTypeAttribute;
+    value: string | number;
+  }
+
+  export let label: string | undefined = undefined;
+  export let id: string = crypto.randomUUID();
+  export let name: string;
+  export let errorMessage: string | undefined = undefined;
+  export let value: string | number;
+  export let type: HTMLInputTypeAttribute = 'text';
+  export let options: Array<string>;
+
+  const inputProps = {
+    class: twMerge(
+      'w-full px-4 h-full rounded-lg outline-none bg-transparent text-color',
+      $$slots.prefix && 'pl-9',
+      $$slots.suffix && 'pr-12'
+    ),
+    id,
+    name,
+    ...$$restProps
+  };
+</script>
+
+<div class="flex flex-col gap-2">
+  {#if label}
+    <label for={id} class="ml-1 text-sm text-color">
+      {label}
+    </label>
+  {/if}
+
+  <div
+    class={twMerge(
+      'rounded-md dark:bg-shadeD400  ring-1 ring-gray-300 dark:ring-gray-500 flex items-center h-[40px] text-color relative focus-within:ring-2 focus-within:ring-gray-400 transition group',
+      errorMessage && '!ring-red-600 ring-2 '
+    )}
+  >
+    {#if $$slots.prefix}
+      <div class="absolute flex items-center justify-center -translate-y-1/2 left-2 top-1/2">
+        <slot name="prefix" />
+      </div>
+    {/if}
+
+    <select bind:value on:input {...inputProps}>
+      {#each options as option}
+      <option>{option}</option>
+      {/each}
+    </select>
+
+    {#if $$slots.suffix}
+      <div class="absolute flex items-center justify-center -translate-y-1/2 right-2 top-1/2">
+        <slot name="suffix" />
+      </div>
+    {/if}
+  </div>
+
+  {#if errorMessage}
+    <span class="ml-1 text-xs font-medium text-red-600">
+      {errorMessage}
+    </span>
+  {/if}
+</div>

--- a/src/lib/domain/Topic.ts
+++ b/src/lib/domain/Topic.ts
@@ -11,6 +11,8 @@ export type Topic = {
   messageExpiryFormatted: string;
   partitionsCount: number;
   createdAt: string;
+  compressionAlgorithm: number;
+  maxTopicSize: number;
 };
 
 export function topicMapper(item: any): Topic {
@@ -20,11 +22,13 @@ export function topicMapper(item: any): Topic {
     name: item.name,
     sizeBytes: item.size,
     sizeFormatted: bytesFormatter(item.size),
-    messageExpiry: item.message_expiry ?? 0,
+    messageExpiry: messageExpiry,
     messageExpiryFormatted: format_expiry(messageExpiry),
     messagesCount: item.messages_count,
     partitionsCount: item.partitions_count,
-    createdAt: formatDate(item.created_at)
+    createdAt: formatDate(item.created_at),
+    compressionAlgorithm: item.compression_algorithm ?? 0,
+    maxTopicSize: item.max_topic_size,
   };
 }
 
@@ -33,11 +37,11 @@ function format_expiry(expiry: number): string {
     return 'never';
   }
 
-  let ms = expiry / 1000;
-  let seconds = ms / 1000;
-  let minutes = (ms / (1000 * 60));
-  let hours = (ms / (1000 * 60 * 60));
-  let days = (ms / (1000 * 60 * 60 * 24));
+  const ms = expiry / 1000;
+  const seconds = ms / 1000;
+  const minutes = (ms / (1000 * 60));
+  const hours = (ms / (1000 * 60 * 60));
+  const days = (ms / (1000 * 60 * 60 * 24));
   if (seconds < 60) {
     return seconds + " second(s)";
   }


### PR DESCRIPTION
Hello!

## Goal

Following the [issue](https://github.com/iggy-rs/iggy-web-ui/issues/3) reported about topic creation, I provide this fix to repair the form.

- Form works
- UI respects current style
- Introduction of `Select` component (base on `Input`), used to choose which compression algorithm should be used for the topic.

![image](https://github.com/user-attachments/assets/b8150ea6-153d-4b13-80b1-ea955ff4ade9)

## Attention required

- I don't have any business knowledge about the API, please validate data that are sent are correct.
- `max_topic_size` was also missed (I do not why, because it has a default value [here](https://github.com/iggy-rs/iggy/blob/master/sdk/src/utils/topic_size.rs#L12)). According the API, i needed to provide a big value to be accepted (`1_000_000_000`) but also, I don't know if it's correct. Once we would have defined which value is correct (+ min/max), we could use a library like [this](https://www.npmjs.com/package/pretty-bytes) to improve the UI.

Thanks for your work!
