### PR TITLE
fix: invalid date crash the UI

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1286,9 +1286,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001651",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001651.tgz",
-      "integrity": "sha512-9Cf+Xv1jJNe1xPZLGuUXLNkE1BoDkqRqYyFJ9TDYSqhduqA4hu4oR9HluGoWYQC/aj8WHjsGVV+bwkh0+tegRg==",
+      "version": "1.0.30001700",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001700.tgz",
+      "integrity": "sha512-2S6XIXwaE7K7erT8dY+kLQcpa5ms63XlRkMkReXjle+kf6c5g38vyMl+Z5y8dSxOFDhcFe+nxnn261PLxBSQsQ==",
       "dev": true,
       "funding": [
         {
@@ -1303,7 +1303,8 @@
           "type": "github",
           "url": "https://github.com/sponsors/ai"
         }
-      ]
+      ],
+      "license": "CC-BY-4.0"
     },
     "node_modules/chalk": {
       "version": "4.1.2",

--- a/src/lib/domain/Stats.ts
+++ b/src/lib/domain/Stats.ts
@@ -1,4 +1,3 @@
-import { bytesFormatter } from '$lib/utils/formatters/bytesFormatter';
 import { intervalToDuration, formatDuration } from 'date-fns';
 
 type StatsStringItem = { name: string; value: string; rawValue: string | number };
@@ -42,7 +41,7 @@ export function statsMapper(item: any): Stats {
   );
 
   const formattedStartTime = formatDuration(
-    intervalToDuration({ start: 0, end: item.start_time * 1000 }),
+    intervalToDuration({ start: 0, end: item.start_time }),
     {
       format: ['hours', 'minutes', 'seconds'],
       zero: true,


### PR DESCRIPTION
Hey!

I started UI locally and then I had a crash. I did the same with main branch and I saw that there is an issue with the date. This change fixes the problem, for this case.

```
# I displayed the date "item.start_time"
1740237508000000

# Error
RangeError: End Date is invalid
    at Proxy.intervalToDuration (PATH/iggy-web-ui/node_modules/date-fns/intervalToDuration/index.js:46:35)
    at Module.statsMapper (PATH/iggy-web-ui/src/lib/domain/Stats.ts:46:5)
    at load (PATH/iggy-web-ui/src/routes/dashboard/overview/+page.server.ts:15:12)
    at process.processTicksAndRejections (node:internal/process/task_queues:105:5)
    at async Module.load_server_data (PATH/iggy-web-ui/node_modules/@sveltejs/kit/src/runtime/server/page/load_data.js:51:17)
    at async eval (PATH/iggy-web-ui/node_modules/@sveltejs/kit/src/runtime/server/page/index.js:141:13)
``` 

Is there a more complexe case to handle here?