### PR TITLE
feat: Enhance expiry display in modals and streams view

### DIFF
--- a/src/lib/components/Modals/AddTopicModal.svelte
+++ b/src/lib/components/Modals/AddTopicModal.svelte
@@ -32,7 +32,7 @@
       .min(1, 'Name must contain at least 1 character')
       .max(255, 'Name must not exceed 255 characters'),
     partitions_count: z.number().min(0).max(numberSizes.max.u32).default(1),
-    message_expiry: z.number().min(0).max(numberSizes.max.u32),
+    message_expiry: z.number().min(0).max(numberSizes.max.u32).default(0),
     compression_algorithm: z.enum(["none", "gzip"]).default("none"),
     max_topic_size: z.number().min(0).max(numberSizes.max.u32).default(1_000_000_000),
   });

--- a/src/lib/components/Modals/AddTopicModal.svelte
+++ b/src/lib/components/Modals/AddTopicModal.svelte
@@ -111,7 +111,13 @@
     />
 
     <span class="-mt-1 text-xs text-shadeD200 dark:text-shadeL700">
-      {durationFormatter(+$form.message_expiry || 0)}
+      {#if !$form.message_expiry || $form.message_expiry > numberSizes.max.u32}
+        {#if $form.message_expiry === 0}
+          never
+        {/if}
+      {:else}
+        {durationFormatter(+$form.message_expiry)}
+      {/if}
     </span>
 
     <Select

--- a/src/lib/components/Modals/TopicSettingsModal.svelte
+++ b/src/lib/components/Modals/TopicSettingsModal.svelte
@@ -20,6 +20,7 @@
   import { numberSizes } from '$lib/utils/constants/numberSizes';
   import { page } from '$app/state';
   import { customInvalidateAll } from '../PeriodicInvalidator.svelte';
+  import { durationFormatter } from '$lib/utils/formatters/durationFormatter';
 
   interface Props {
     topic: TopicDetails;
@@ -136,6 +137,16 @@
         {...$constraints.message_expiry}
         errorMessage={$errors.message_expiry?.join(',')}
       />
+
+      <span class="-mt-1 text-xs text-shadeD200 dark:text-shadeL700">
+        {#if !$form.message_expiry || $form.message_expiry > numberSizes.max.u32}
+          {#if $form.message_expiry === 0}
+            never
+          {/if}
+        {:else}
+          {durationFormatter(+$form.message_expiry)}
+        {/if}
+      </span>
 
       <div class="flex justify-end gap-3 w-full mt-auto">
         <Button type="button" variant="text" class="w-2/5" on:click={() => closeModal()}

--- a/src/lib/domain/Topic.ts
+++ b/src/lib/domain/Topic.ts
@@ -1,5 +1,7 @@
+import { numberSizes } from '$lib/utils/constants/numberSizes';
 import { bytesFormatter } from '$lib/utils/formatters/bytesFormatter';
 import { formatDate } from '$lib/utils/formatters/dateFormatter';
+import { durationFormatter } from '$lib/utils/formatters/durationFormatter';
 
 export type Topic = {
   id: number;
@@ -16,14 +18,14 @@ export type Topic = {
 };
 
 export function topicMapper(item: any): Topic {
-  const messageExpiry = item.message_expiry ?? 0;
+  const messageExpirySeconds = item.message_expiry == null || item.message_expiry >= numberSizes.max.u32 ? 0 : item.message_expiry;
   return {
     id: item.id,
     name: item.name,
     sizeBytes: item.size,
     sizeFormatted: bytesFormatter(item.size),
-    messageExpiry: messageExpiry,
-    messageExpiryFormatted: format_expiry(messageExpiry),
+    messageExpiry: messageExpirySeconds,
+    messageExpiryFormatted: formatExpiry(messageExpirySeconds),
     messagesCount: item.messages_count,
     partitionsCount: item.partitions_count,
     createdAt: formatDate(item.created_at),
@@ -32,26 +34,10 @@ export function topicMapper(item: any): Topic {
   };
 }
 
-function format_expiry(expiry: number): string {
-  if (expiry === 0 || expiry >= 18446744073709551615n) {
+function formatExpiry(expiry: number): string {
+  if (expiry === 0 || expiry >= numberSizes.max.u32) {
     return 'never';
   }
 
-  const ms = expiry / 1000;
-  const seconds = ms / 1000;
-  const minutes = (ms / (1000 * 60));
-  const hours = (ms / (1000 * 60 * 60));
-  const days = (ms / (1000 * 60 * 60 * 24));
-  if (seconds < 60) {
-    return seconds + " second(s)";
-  }
-  else if (minutes < 60) { 
-    return minutes.toFixed(1) + " minute(s)";
-  }
-  else if (hours < 24) {
-    return hours.toFixed(1) + " hour(s)";
-  }
-  else {
-    return days.toFixed(1) + " day(s)"
-  }
+  return durationFormatter(expiry);
 }


### PR DESCRIPTION
Hi guys! First of all thanks for this great project. There's a tonne of cool features already. I got a crack on the UI and tried to update `message_expiry` across modals and views.

My PR introduces following changes:
- modified span in `AddTopicModal` that displays value in human readable format
- modified span in `TopicSettingsModal` that displays value in human readable format
- updated expiration topics view under `/dashboard/streams/[id]`
    - before: ![image](https://github.com/user-attachments/assets/f5739b66-e356-4638-ab91-44312d90e691)
    - after: ![image](https://github.com/user-attachments/assets/247526cb-6700-4a65-ac73-3b399bad387e)

Let me know what you think :)